### PR TITLE
Support finding a user by their email address rather than name

### DIFF
--- a/bootstrap/docker-compose.yml
+++ b/bootstrap/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     environment:
       VAULT_LOCAL_CONFIG: '{"plugin_directory":"/etc/vault/plugins"}'
       VAULT_DEV_ROOT_TOKEN_ID: root
+      VAULT_LOG_LEVEL: debug
     volumes:
       - ".././bin:/etc/vault/plugins"
     networks:

--- a/internal/plugin/delete_user.go
+++ b/internal/plugin/delete_user.go
@@ -38,7 +38,7 @@ func (r *redisEnterpriseDB) findAndDeleteUser(ctx context.Context, username stri
 		return err
 	}
 
-	r.logger.Debug("delete user", "username", username, "uid", user.UID)
+	r.logger.Debug("delete user", "user", username, "uid", user.UID)
 
 	if err := r.client.DeleteUser(ctx, user.UID); err != nil {
 		return fmt.Errorf("cannot delete user %s: %w", username, err)
@@ -58,7 +58,7 @@ func (r redisEnterpriseDB) findAndDeleteRole(ctx context.Context, username strin
 		return err
 	}
 
-	r.logger.Debug("delete role", "name", role.Name, "uid", role.UID)
+	r.logger.Debug("delete role", "role", role.Name, "uid", role.UID)
 
 	// Found the role with the expected name, so have to assume it was the generated role
 	// Any role permissions associated with the role will be deleted by Redis Enterprise

--- a/internal/plugin/new_user_test.go
+++ b/internal/plugin/new_user_test.go
@@ -285,7 +285,7 @@ func TestRedisEnterpriseDB_NewUser_createRoleFailureRollsBackCorrectly(t *testin
 }
 
 func matchesContext(ctx context.Context) interface{} {
-	return mock.MatchedBy(func(ctx2 context.Context) bool { return ctx2 == ctx })
+	return mock.MatchedBy(func(ctxArg context.Context) bool { return ctxArg == ctx })
 }
 
 func matchesCreateRole(management string, dbName string, displayName string, roleName string) interface{} {
@@ -320,6 +320,10 @@ func matchesCreateUser(displayName string, roleName string, roleId int, password
 		}
 
 		if c.Password != password {
+			return false
+		}
+
+		if c.Email != "" {
 			return false
 		}
 

--- a/internal/sdk/model.go
+++ b/internal/sdk/model.go
@@ -9,11 +9,13 @@ type User struct {
 	Role              string `json:"role"`
 	Roles             []int  `json:"role_uids,omitempty"`
 	Name              string `json:"name"`
+	Email             string `json:"email"`
 	PasswordIssueDate string `json:"password_issue_date"`
 }
 
 type CreateUser struct {
 	Name        string `json:"name,omitempty"`
+	Email       string `json:"email,omitempty"`
 	Password    string `json:"password,omitempty"`
 	Roles       []int  `json:"role_uids,omitempty"`
 	EmailAlerts bool   `json:"email_alerts"`

--- a/internal/sdk/test_utils_test.go
+++ b/internal/sdk/test_utils_test.go
@@ -1,0 +1,34 @@
+package sdk
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func testServer(t *testing.T, path string, method string, expectedUsername string, expectedPassword string, f func(w http.ResponseWriter, r *http.Request)) string {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !assert.Equal(t, path, r.URL.Path) || !assert.Equal(t, method, r.Method) {
+			http.Error(w, "invalid request", http.StatusInternalServerError)
+			return
+		}
+
+		var ok bool
+		username, password, ok := r.BasicAuth()
+		if !assert.True(t, ok) || !assert.Equal(t, expectedUsername, username) || !assert.Equal(t, expectedPassword, password) {
+			http.Error(w, "basic auth failure", http.StatusInternalServerError)
+			return
+		}
+
+		f(w, r)
+	}))
+
+	t.Cleanup(func() {
+		server.Close()
+	})
+
+	return server.URL
+}

--- a/internal/sdk/users.go
+++ b/internal/sdk/users.go
@@ -15,6 +15,14 @@ func (c *Client) ListUsers(ctx context.Context) ([]User, error) {
 	return body, nil
 }
 
+func (c *Client) GetUser(ctx context.Context, id int) (User, error) {
+	var body User
+	if err := c.request(ctx, http.MethodGet, fmt.Sprintf("/v1/users/%d", id), nil, &body); err != nil {
+		return User{}, err
+	}
+	return body, nil
+}
+
 func (c *Client) CreateUser(ctx context.Context, create CreateUser) (User, error) {
 	var body User
 	if err := c.request(ctx, http.MethodPost, "/v1/users", create, &body); err != nil {
@@ -40,6 +48,8 @@ func (c *Client) DeleteUser(ctx context.Context, id int) error {
 	return nil
 }
 
+// FindUserByName attempts to find a user, using the same behaviour as the Redis Enterprise UI -
+// attempt to find the user by the `name` field and then try `email`.
 func (c *Client) FindUserByName(ctx context.Context, name string) (User, error) {
 	users, err := c.ListUsers(ctx)
 	if err != nil {
@@ -48,6 +58,12 @@ func (c *Client) FindUserByName(ctx context.Context, name string) (User, error) 
 
 	for _, user := range users {
 		if user.Name == name {
+			return user, nil
+		}
+	}
+
+	for _, user := range users {
+		if user.Email == name {
 			return user, nil
 		}
 	}

--- a/internal/sdk/users_test.go
+++ b/internal/sdk/users_test.go
@@ -1,0 +1,58 @@
+package sdk
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_FindUserByName_useNameFirst(t *testing.T) {
+	expectedId := 2
+	name := "needle"
+	username := "expected"
+	password := "Password"
+
+	url := testServer(t, "/v1/users", http.MethodGet, username, password, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, `[{"uid":-1,"name":"other","email":%[2]q},{"uid":%[1]d,"name":%[2]q}]`, expectedId, name)
+	})
+
+	subject := &Client{
+		url:      url,
+		username: username,
+		password: password,
+		client:   http.DefaultClient,
+	}
+
+	actual, err := subject.FindUserByName(context.Background(), name)
+	require.NoError(t, err)
+
+	assert.Equal(t, expectedId, actual.UID)
+}
+
+func TestClient_FindUserByName_fallBackToEmail(t *testing.T) {
+	expectedId := 2
+	name := "needle"
+
+	username := "expected"
+	password := "Password"
+
+	url := testServer(t, "/v1/users", http.MethodGet, username, password, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, `[{"uid":-1,"name":"other","email":"foo@example.com"},{"uid":%[1]d,"email":%[2]q}]`, expectedId, name)
+	})
+
+	subject := &Client{
+		url:      url,
+		username: username,
+		password: password,
+		client:   http.DefaultClient,
+	}
+
+	actual, err := subject.FindUserByName(context.Background(), name)
+	require.NoError(t, err)
+
+	assert.Equal(t, expectedId, actual.UID)
+}


### PR DESCRIPTION
It is possible that a static or root user for the plugin would be configured using the email address of the user rather than the username - as Redis Enterprise will happily authenticate based on the email rather than username. If the email address is used, then `FindUserByName` would fail to find the user as it only checked the name, so `UpdateUser` would fail, and Vault wouldn't be able to rotate root user credentials.