### PR TITLE
Update go version to 1.16 and kind to v0.11.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push]
 
 env:
-  GO_VERSION: "1.15"
+  GO_VERSION: "1.16"
 
 jobs:
   build:
@@ -32,7 +32,7 @@ jobs:
         uses: engineerd/setup-kind@v0.5.0
         with:
           config: bootstrap/kind-config.yml
-          version: v0.9.0
+          version: v0.11.1
 
       - name: Test Kubernetes
         run: kubectl cluster-info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
This PR updates the Kind and Go lang versions used with the build pipeline.  Upon a recent build the pipeline failed to install the Redis Enterprise Database Operator within the pipeline's k8s cluster.  Updating the version of Kind solved this problems when updated to v0.11.*.

The build pipeline worked with Ubuntu 18.04 LTS and a recent notification mentions that the `ubuntu-latest` tag will point the Ubuntu 20.04.LTS.  The build pipeline was successful against the latest Ubuntu tag.

As a part of general house keeping the Go lang version was updated and again the build pipeline executed successfully.