### PR TITLE
Updates to Redis Enterprise k8s Operator to v6.0.20-12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,11 @@ jobs:
 
       - name: Install Redis Enterprise operator
         run: |
-          curl --silent --fail https://raw.githubusercontent.com/RedisLabs/redis-enterprise-k8s-docs/v6.0.12-5/bundle.yaml | kubectl apply -f -
+          curl --silent --fail https://raw.githubusercontent.com/RedisLabs/redis-enterprise-k8s-docs/v6.0.20-12/bundle.yaml | kubectl apply -f -
           kubectl rollout status deployment/redis-enterprise-operator --watch --timeout=5m || kubectl describe pod -lname=redis-enterprise-operator
 
       - name: Install cluster
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: |
           cat <<EOF |
           apiVersion: "app.redislabs.com/v1"
@@ -51,7 +51,7 @@ jobs:
           metadata:
             name: "test-cluster"
           spec:
-            nodes: 1
+            nodes: 3
             redisEnterpriseNodeResources:
               limits:
                 cpu: 1000m
@@ -66,6 +66,9 @@ jobs:
             kubectl get redisenterpriseclusters.app.redislabs.com test-cluster --output jsonpath='{.status}{"\n"}'
             sleep 5;
           done
+          echo "waiting loop has finished."
+          sleep 5;
+          kubectl get redisenterpriseclusters.app.redislabs.com test-cluster --output jsonpath='{.status}{"\n"}'
 
       - name: Install database
         timeout-minutes: 5
@@ -90,6 +93,9 @@ jobs:
             kubectl get redisenterprisedatabase.app.redislabs.com mydb --output jsonpath='{.status}{"\n"}'
             sleep 5;
           done
+          echo "waiting loop has finished."
+          sleep 5;
+          kubectl get redisenterprisedatabase.app.redislabs.com mydb --output jsonpath='{.status}{"\n"}'
 
       - name: Install a service to expose the Redis cluster on a port
         run: |

--- a/bootstrap/kind-config.yml
+++ b/bootstrap/kind-config.yml
@@ -7,4 +7,10 @@ nodes:
         hostPort: 30000
         listenAddress: "0.0.0.0"
         protocol: tcp
+    image: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
   - role: worker
+    image: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
+  - role: worker
+    image: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
+  - role: worker
+    image: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9


### PR DESCRIPTION
The following PR has been raised to adjust the CI pipeline to test the Vault Plugin against the latest version of the Redis Enterprise k8s Operator, (currently v6.0.20-12).  Configuration has been adjust to increase the cluster size and timeout periods to initialise and test.

- Increases timeout for Install cluster step to 10 minutes
- Increases RedisEnterpriseCluster nodes to 3 to align with operator docs
- Update kind-config.yml to set k8s to version 1.20 to align with operator docs
- Adds k8s get command to install database and install cluster steps for confirmation