### PR TITLE
RED-144637 - close the connecton after issuing a request

### DIFF
--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -68,6 +68,7 @@ func (c *Client) request(ctx context.Context, method string, path string, reques
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, url, requestBodyReader)
+	req.Close = true
 	if err != nil {
 		return fmt.Errorf("unable to perform request %s %s: %w", method, path, err)
 	}


### PR DESCRIPTION
We suspect that connections are not closed properly, leading to overloading envoy and API availability issues.