### PR TITLE
RED-196767: Fix vault-plugin-database-redis-enterprise release CI (GoReleaser v0.1.6 failure)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
 
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2.1.3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Checkout Repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4
 
       - name: Module and build cache
         uses: actions/cache@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,19 +10,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Unshallow
         run: git fetch --prune --unshallow
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.26.2
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: 1.24.0
-          args: release --rm-dist
+          version: ~> v2
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,6 +35,8 @@ builds:
         goarch: arm
       - goos: openbsd
         goarch: arm64
+      - goos: windows
+        goarch: arm
     binary: '{{ .ProjectName }}_{{ .Version }}'
 archives:
   - format: binary


### PR DESCRIPTION
## Summary

- Remove `windows/arm` build target from `.goreleaser.yml` — Go 1.22+ dropped support for this GOOS/GOARCH pair, causing the v0.1.6 release to fail
- Upgrade `actions/checkout` and `actions/setup-go` to v4 in both `ci.yml` and `release.yml`
- Upgrade `goreleaser/goreleaser-action` to v6 (GoReleaser v2), replacing deprecated `--rm-dist` flag with `--clean`

## Test plan

- [ ] Push a test tag (e.g. `v0.1.7-rc1`) and verify the release workflow completes without the `windows/arm` error
- [ ] Confirm a release draft is created in GitHub with the expected assets (matching v0.1.5 minus `windows_arm.exe`)
- [ ] Verify CI workflow passes with the upgraded Actions

Jira: [RED-196767](https://redislabs.atlassian.net/browse/RED-196767)

🤖 Generated with [Claude Code](https://claude.com/claude-code)