### PR TITLE
RED-196767: Migrate .goreleaser.yml to v2 schema and add dry-run workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,12 @@
 # This GitHub action can publish assets for release when a tag is created.
 # Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
+# A manual workflow_dispatch run is always a dry-run (snapshot, no publish).
 name: release
 on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -23,6 +25,14 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: ~> v2
-          args: release --clean
+          args: ${{ github.event_name == 'workflow_dispatch' && 'release --snapshot --clean --skip=publish' || 'release --clean' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload dry-run artifacts
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dry-run-dist
+          path: dist/
+          retention-days: 7

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - go mod download
@@ -39,7 +40,7 @@ builds:
         goarch: arm
     binary: '{{ .ProjectName }}_{{ .Version }}'
 archives:
-  - format: binary
+  - formats: [binary]
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
@@ -47,4 +48,4 @@ checksum:
 release:
   draft: true
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
## Summary

Follow-up to #23. The previous PR fixed the GitHub Actions versions and removed the invalid `windows/arm` target, but a test run of the release workflow surfaced two additional issues:

- **GoReleaser v2 schema migration** — v2 requires `version: 2` in the config. Also migrated deprecated fields: `archives.format` → `archives.formats` (list) and `changelog.skip` → `changelog.disable`.
- **Manual dry-run trigger** — added `workflow_dispatch` to the release workflow. Manual runs always execute `release --snapshot --clean --skip=publish` and upload the `dist/` folder as an artifact. Tag pushes still trigger the real release.

## Test plan

- [ ] Trigger the release workflow manually from the Actions tab — verify it completes successfully and uploads a `dry-run-dist` artifact
- [ ] Inspect the artifact contents to confirm all expected binaries are present
- [ ] Push a real tag (e.g. `v0.1.7`) and verify the published release looks correct

Jira: [RED-196767](https://redislabs.atlassian.net/browse/RED-196767)